### PR TITLE
Update zip build to include material-theme folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,7 @@ module.exports = function( grunt ) {
 				command: './vendor/xwp/wp-dev-lib/scripts/generate-markdown-readme', // Generate the readme.md.
 			},
 			create_build_zip: {
-				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e material-theme.zip ]; then rm material-theme.zip; fi; cd build; zip -r ../material-theme.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/material-theme.zip"',
+				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e material-theme.zip ]; then rm material-theme.zip; fi; mv build material-theme; zip -r ./material-theme.zip material-theme; mv material-theme build; echo; echo "ZIP of build: $(pwd)/material-theme.zip"',
 			},
 		},
 	} );


### PR DESCRIPTION
Fixes xwp/material-theme-builder-wp#313.

Currently the theme zip contains all the theme files and folders at the root of the zip and this causes an issues with `Theme_Upgrader` when it unzips the zip and moves the contents to a temp folder. This fix will change the zip file to contain a root folder `material-theme` and moves all the theme files to the root folder.