### PR TITLE
Suppress plugin installation notice if WP_DEBUG is true

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -64,6 +64,11 @@ function plugin_not_installed_notice() {
 		return;
 	}
 
+	// Supress notice if WP_DEBUG is true.
+	if ( defined( '\WP_DEBUG' ) && \WP_DEBUG ) {
+		return;
+	}
+
 	$args = [
 		'page'             => 'tgmpa-install-plugins',
 		'plugin'           => $plugin,


### PR DESCRIPTION
This PR suppresses the admin notice telling you to install the theme builder plugin when WP_DEBUG is true. This is a counterpart to this ticket from the theme builder repo: https://github.com/xwp/material-theme-builder-wp/issues/400